### PR TITLE
Introduce pluggable storage and upload services

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,17 +3,17 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
 import { registerSW } from 'virtual:pwa-register'
+import { IndexedDbStorage } from './services/indexed-db'
+import { HttpUploader } from './services/http-uploader'
 
 registerSW({ immediate: true })
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-)
+const storage = new IndexedDbStorage()
+const uploader = new HttpUploader()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <App storage={storage} uploader={uploader} />
+  </React.StrictMode>,
 )
+

--- a/src/services/http-uploader.ts
+++ b/src/services/http-uploader.ts
@@ -1,0 +1,59 @@
+import { Clip } from "../models/clip";
+import { ApiConfig, UploadResult, UploadService } from "./types";
+
+function joinUrl(base: string, path: string) {
+  const b = (base || "").replace(/\/+$/, "");
+  const p = (path || "").replace(/^\/+/, "");
+  return `${b}/${p}`;
+}
+
+function notesUrl(base: string, uploadPath: string) {
+  const p = ("/" + (uploadPath || "/notes").replace(/^\/+/, "")).replace(/\/+$/, "");
+  const full = joinUrl(base, p);
+  const u = new URL(full);
+  return u.toString();
+}
+
+export class HttpUploader implements UploadService {
+  async upload(clip: Clip, api: ApiConfig): Promise<UploadResult> {
+    const blob = clip.blob;
+    if (!blob) throw new Error("Audio blob not found");
+
+    const fd = new FormData();
+    const filename = `note-${clip.id}.${clip.mimeType.includes("mp4") ? "m4a" : "webm"}`;
+    fd.append("file", blob, filename);
+    fd.append("createdAt", String(clip.createdAt));
+    if (clip.title) fd.append("title", clip.title);
+    if (clip.tags?.length) fd.append("tags", JSON.stringify(clip.tags));
+
+    const res = await fetch(notesUrl(api.baseUrl, api.uploadPath), {
+      method: "POST",
+      body: fd,
+    });
+    if (!res.ok) {
+      const txt = await res.text();
+      throw new Error(`Upload failed: ${res.status} ${txt}`);
+    }
+
+    let data: any = {};
+    try { data = await res.json(); } catch {}
+
+    let serverId: string | undefined = data?.id;
+    if (!serverId) {
+      const loc = res.headers.get("Location") || res.headers.get("Content-Location");
+      if (loc) {
+        const u = new URL(loc, api.baseUrl || window.location.origin);
+        serverId = u.searchParams.get("id") || u.searchParams.get("job") || undefined;
+      }
+    }
+    if (!serverId) throw new Error("Server did not return an id");
+
+    return {
+      serverId,
+      title: data?.title,
+      tags: Array.isArray(data?.tags) ? data.tags : undefined,
+      details: data?.details,
+      transcriptUrl: data?.transcriptUrl,
+    };
+  }
+}

--- a/src/services/indexed-db.ts
+++ b/src/services/indexed-db.ts
@@ -1,9 +1,10 @@
 import { Clip } from "../models/clip";
+import { StorageService } from "./types";
 
 const DB_NAME = "voice-notes-db";
 const STORE = "clips";
 
-export async function openDb(): Promise<IDBDatabase> {
+async function openDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const req = indexedDB.open(DB_NAME, 1);
     req.onupgradeneeded = () => {
@@ -18,36 +19,38 @@ export async function openDb(): Promise<IDBDatabase> {
   });
 }
 
-export async function idbPut(clip: Clip) {
-  const db = await openDb();
-  return new Promise<void>((resolve, reject) => {
-    const tx = db.transaction(STORE, "readwrite");
-    const st = tx.objectStore(STORE);
-    const { objectUrl, ...persistable } = clip;
-    const rq = st.put(persistable);
-    rq.onsuccess = () => resolve();
-    rq.onerror = () => reject(rq.error);
-  });
-}
+export class IndexedDbStorage implements StorageService {
+  async save(clip: Clip): Promise<void> {
+    const db = await openDb();
+    return new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, "readwrite");
+      const st = tx.objectStore(STORE);
+      const { objectUrl, ...persistable } = clip;
+      const rq = st.put(persistable);
+      rq.onsuccess = () => resolve();
+      rq.onerror = () => reject(rq.error);
+    });
+  }
 
-export async function idbGetAll(): Promise<Clip[]> {
-  const db = await openDb();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(STORE, "readonly");
-    const st = tx.objectStore(STORE);
-    const rq = st.getAll();
-    rq.onsuccess = () => resolve(rq.result as Clip[]);
-    rq.onerror = () => reject(rq.error);
-  });
-}
+  async getAll(): Promise<Clip[]> {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, "readonly");
+      const st = tx.objectStore(STORE);
+      const rq = st.getAll();
+      rq.onsuccess = () => resolve(rq.result as Clip[]);
+      rq.onerror = () => reject(rq.error);
+    });
+  }
 
-export async function idbDelete(id: string) {
-  const db = await openDb();
-  return new Promise<void>((resolve, reject) => {
-    const tx = db.transaction(STORE, "readwrite");
-    const st = tx.objectStore(STORE);
-    const rq = st.delete(id);
-    rq.onsuccess = () => resolve();
-    rq.onerror = () => reject(rq.error);
-  });
+  async remove(id: string): Promise<void> {
+    const db = await openDb();
+    return new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, "readwrite");
+      const st = tx.objectStore(STORE);
+      const rq = st.delete(id);
+      rq.onsuccess = () => resolve();
+      rq.onerror = () => reject(rq.error);
+    });
+  }
 }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,0 +1,28 @@
+import { Clip } from "../models/clip";
+
+export interface StorageService {
+  /** Save or update a clip */
+  save(clip: Clip): Promise<void>;
+  /** Retrieve all clips */
+  getAll(): Promise<Clip[]>;
+  /** Remove clip by id */
+  remove(id: string): Promise<void>;
+}
+
+export type ApiConfig = {
+  baseUrl: string;
+  uploadPath: string;
+  authToken?: string;
+};
+
+export interface UploadResult {
+  serverId: string;
+  title?: string;
+  tags?: string[];
+  details?: string;
+  transcriptUrl?: string;
+}
+
+export interface UploadService {
+  upload(clip: Clip, api: ApiConfig): Promise<UploadResult>;
+}


### PR DESCRIPTION
## Summary
- define `StorageService` and `UploadService` interfaces
- add `IndexedDbStorage` and `HttpUploader` implementations
- wire `App` to service interfaces via props for future pluggable backends

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba592dbf408330ab7b0fefddb3f7a7