### PR TITLE
Add runtime validation and service swap tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Test build artifacts
+.tmp
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "deploy": "vite build && gh-pages -d dist"
+    "deploy": "vite build && gh-pages -d dist",
+    "test": "tsc src/services/services.test.ts --module commonjs --moduleResolution node --target ES2020 --esModuleInterop --outDir .tmp && node --test .tmp/services/services.test.js"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "deploy": "vite build && gh-pages -d dist",
-    "test": "tsc src/services/services.test.ts --module commonjs --moduleResolution node --target ES2020 --esModuleInterop --outDir .tmp && node --test .tmp/services/services.test.js"
+    "test": "tsc src/services/*.ts src/models/clip.ts --module commonjs --moduleResolution node --target ES2020 --esModuleInterop --outDir .tmp && echo '{\"type\":\"commonjs\"}' > .tmp/package.json && mv .tmp/services/services.test.js .tmp/services/services.test.cjs && node --test .tmp/services/services.test.cjs"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "deploy": "vite build && gh-pages -d dist",
-    "test": "tsc src/services/*.ts src/models/clip.ts --module commonjs --moduleResolution node --target ES2020 --esModuleInterop --outDir .tmp && echo '{\"type\":\"commonjs\"}' > .tmp/package.json && mv .tmp/services/services.test.js .tmp/services/services.test.cjs && node --test .tmp/services/services.test.cjs"
+    "test": "node scripts/test-services.cjs"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/scripts/test-services.cjs
+++ b/scripts/test-services.cjs
@@ -1,0 +1,6 @@
+const { execSync } = require('node:child_process');
+const { writeFileSync } = require('node:fs');
+
+execSync('tsc -p tsconfig.test.json', { stdio: 'inherit' });
+writeFileSync('.tmp/package.json', JSON.stringify({ type: 'commonjs' }));
+execSync('node --test .tmp/services/services.test.js', { stdio: 'inherit' });

--- a/src/node-test.d.ts
+++ b/src/node-test.d.ts
@@ -1,0 +1,8 @@
+declare module 'node:test' {
+  export function test(name: string, fn: () => void | Promise<void>): void;
+}
+
+declare module 'node:assert/strict' {
+  const assert: any;
+  export default assert;
+}

--- a/src/services/assert.ts
+++ b/src/services/assert.ts
@@ -1,0 +1,5 @@
+export function assertNonEmpty(value: string | undefined | null, name: string): asserts value is string {
+  if (!value) {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+}

--- a/src/services/http-uploader.ts
+++ b/src/services/http-uploader.ts
@@ -1,13 +1,14 @@
 import { Clip } from "../models/clip";
+import { assertNonEmpty } from "./assert";
 import { ApiConfig, UploadResult, UploadService } from "./types";
 
-function joinUrl(base: string, path: string) {
+function joinUrl(base: string, path: string): string {
   const b = (base || "").replace(/\/+$/, "");
   const p = (path || "").replace(/^\/+/, "");
   return `${b}/${p}`;
 }
 
-function notesUrl(base: string, uploadPath: string) {
+function notesUrl(base: string, uploadPath: string): string {
   const p = ("/" + (uploadPath || "/notes").replace(/^\/+/, "")).replace(/\/+$/, "");
   const full = joinUrl(base, p);
   const u = new URL(full);
@@ -15,7 +16,13 @@ function notesUrl(base: string, uploadPath: string) {
 }
 
 export class HttpUploader implements UploadService {
+  /**
+   * @inheritdoc
+   */
   async upload(clip: Clip, api: ApiConfig): Promise<UploadResult> {
+    assertNonEmpty(clip.id, "clip.id");
+    assertNonEmpty(api.baseUrl, "api.baseUrl");
+    assertNonEmpty(api.uploadPath, "api.uploadPath");
     const blob = clip.blob;
     if (!blob) throw new Error("Audio blob not found");
 

--- a/src/services/indexed-db.ts
+++ b/src/services/indexed-db.ts
@@ -1,4 +1,5 @@
 import { Clip } from "../models/clip";
+import { assertNonEmpty } from "./assert";
 import { StorageService } from "./types";
 
 const DB_NAME = "voice-notes-db";
@@ -20,7 +21,11 @@ async function openDb(): Promise<IDBDatabase> {
 }
 
 export class IndexedDbStorage implements StorageService {
+  /**
+   * @inheritdoc
+   */
   async save(clip: Clip): Promise<void> {
+    assertNonEmpty(clip.id, "clip.id");
     const db = await openDb();
     return new Promise<void>((resolve, reject) => {
       const tx = db.transaction(STORE, "readwrite");
@@ -32,6 +37,9 @@ export class IndexedDbStorage implements StorageService {
     });
   }
 
+  /**
+   * @inheritdoc
+   */
   async getAll(): Promise<Clip[]> {
     const db = await openDb();
     return new Promise((resolve, reject) => {
@@ -43,7 +51,11 @@ export class IndexedDbStorage implements StorageService {
     });
   }
 
+  /**
+   * @inheritdoc
+   */
   async remove(id: string): Promise<void> {
+    assertNonEmpty(id, "id");
     const db = await openDb();
     return new Promise<void>((resolve, reject) => {
       const tx = db.transaction(STORE, "readwrite");

--- a/src/services/services.test.ts
+++ b/src/services/services.test.ts
@@ -1,0 +1,100 @@
+/// <reference path="../node-test.d.ts" />
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { IndexedDbStorage } from './indexed-db';
+import { HttpUploader } from './http-uploader';
+import { Clip } from '../models/clip';
+import { ApiConfig, StorageService, UploadResult, UploadService } from './types';
+
+function setupIndexedDb() {
+  const store = new Map<string, any>();
+  (globalThis as any).indexedDB = {
+    open: () => {
+      const request: any = {};
+      setTimeout(() => {
+        const db = {
+          objectStoreNames: { contains: () => false },
+          createObjectStore: () => ({ createIndex: () => {} }),
+          transaction: () => ({
+            objectStore: () => ({
+              put: (value: any) => {
+                store.set(value.id, value);
+                const r: any = {};
+                setTimeout(() => r.onsuccess && r.onsuccess(), 0);
+                return r;
+              },
+              getAll: () => {
+                const r: any = {};
+                setTimeout(() => { r.result = Array.from(store.values()); r.onsuccess && r.onsuccess(); }, 0);
+                return r;
+              },
+              delete: (id: string) => {
+                store.delete(id);
+                const r: any = {};
+                setTimeout(() => r.onsuccess && r.onsuccess(), 0);
+                return r;
+              }
+            })
+          })
+        };
+        request.result = db;
+        request.onupgradeneeded && request.onupgradeneeded();
+        request.onsuccess && request.onsuccess();
+      }, 0);
+      return request;
+    }
+  };
+}
+setupIndexedDb();
+
+class MockStorage implements StorageService {
+  private store = new Map<string, Clip>();
+  async save(clip: Clip): Promise<void> { this.store.set(clip.id, clip); }
+  async getAll(): Promise<Clip[]> { return Array.from(this.store.values()); }
+  async remove(id: string): Promise<void> { this.store.delete(id); }
+}
+
+class MockUploader implements UploadService {
+  async upload(clip: Clip, _api: ApiConfig): Promise<UploadResult> {
+    return { serverId: `mock-${clip.id}` };
+  }
+}
+
+const clip: Clip = {
+  id: '123',
+  createdAt: Date.now(),
+  mimeType: 'audio/webm',
+  status: 'idle',
+  blob: new Blob(['test'], { type: 'text/plain' })
+};
+
+async function exerciseStorage(service: StorageService) {
+  await service.save(clip);
+  const all = await service.getAll();
+  assert.equal(all.length, 1);
+  assert.equal(all[0].id, clip.id);
+  await service.remove(clip.id);
+  const after = await service.getAll();
+  assert.equal(after.length, 0);
+}
+
+test('StorageService allows swapping implementations', async () => {
+  await exerciseStorage(new IndexedDbStorage());
+  await exerciseStorage(new MockStorage());
+});
+
+async function exerciseUploader(service: UploadService) {
+  const api: ApiConfig = { baseUrl: 'https://example.com', uploadPath: '/notes' };
+  const result = await service.upload(clip, api);
+  assert.ok(result.serverId);
+}
+
+test('UploadService allows swapping implementations', async () => {
+  const real = new HttpUploader();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({ id: 'abc' }), { status: 200 }) as any;
+  await exerciseUploader(real);
+  globalThis.fetch = originalFetch;
+
+  await exerciseUploader(new MockUploader());
+});

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,11 +1,22 @@
 import { Clip } from "../models/clip";
 
 export interface StorageService {
-  /** Save or update a clip */
+  /**
+   * Save or update a clip.
+   * @pre clip.id is a non-empty string.
+   * @post the clip can be retrieved via `getAll()`.
+   */
   save(clip: Clip): Promise<void>;
-  /** Retrieve all clips */
+  /**
+   * Retrieve all persisted clips.
+   * @post the returned array contains every clip previously saved.
+   */
   getAll(): Promise<Clip[]>;
-  /** Remove clip by id */
+  /**
+   * Remove a clip by its id.
+   * @pre `id` is a non-empty string.
+   * @post the clip is no longer returned by `getAll()`.
+   */
   remove(id: string): Promise<void>;
 }
 
@@ -24,5 +35,10 @@ export interface UploadResult {
 }
 
 export interface UploadService {
+  /**
+   * Upload a clip to the remote service.
+   * @pre `clip.id` and `clip.blob` are defined and `api.baseUrl`/`uploadPath` are non-empty.
+   * @post resolves with server metadata describing the uploaded clip.
+   */
   upload(clip: Clip, api: ApiConfig): Promise<UploadResult>;
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "outDir": ".tmp"
+  },
+  "include": [
+    "src/services/**/*.ts",
+    "src/models/clip.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- document StorageService and UploadService preconditions and postconditions
- add assert-based runtime validation for clip IDs and API details
- introduce tests ensuring real and mock services are interchangeable

## Testing
- `npm test` *(fails: ReferenceError: exports is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f7806808330b5739d3a9b27272e