### PR TITLE
feat: add services context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,8 @@ import {
   TagIcon,
 } from "./icons";
 import { Clip, toClipStatus } from "./models/clip";
-import type { ApiConfig, ClipStore, UploadService } from "./services/types";
+import type { ApiConfig } from "./services/types";
+import { useStorage, useUploader } from "./context/services";
 
 const fmt = {
   pad(n: number) {
@@ -30,13 +31,9 @@ const fmt = {
   },
 };
 
-export default function App({
-  storage,
-  uploader,
-}: {
-  storage: ClipStore;
-  uploader: UploadService;
-}) {
+export default function App() {
+  const storage = useStorage();
+  const uploader = useUploader();
   const [api, setApi] = useState<ApiConfig>(() => {
     const saved = localStorage.getItem("voiceNotes.api");
     return saved

--- a/src/context/services.tsx
+++ b/src/context/services.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext } from 'react';
+import type { ClipStore, UploadService } from '../services/types';
+
+interface ServicesContextValue {
+  storage: ClipStore;
+  uploader: UploadService;
+}
+
+const ServicesContext = createContext<ServicesContextValue | undefined>(undefined);
+
+export function ServicesProvider({ storage, uploader, children }: React.PropsWithChildren<ServicesContextValue>) {
+  return (
+    <ServicesContext.Provider value={{ storage, uploader }}>
+      {children}
+    </ServicesContext.Provider>
+  );
+}
+
+export function useStorage(): ClipStore {
+  const ctx = useContext(ServicesContext);
+  if (!ctx) throw new Error('useStorage must be used within a ServicesProvider');
+  return ctx.storage;
+}
+
+export function useUploader(): UploadService {
+  const ctx = useContext(ServicesContext);
+  if (!ctx) throw new Error('useUploader must be used within a ServicesProvider');
+  return ctx.uploader;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import './index.css'
 import { registerSW } from 'virtual:pwa-register'
 import { IndexedDbStorage } from './services/indexed-db'
 import { HttpUploader } from './services/http-uploader'
+import { ServicesProvider } from './context/services'
 
 registerSW({ immediate: true })
 
@@ -13,7 +14,9 @@ const uploader = new HttpUploader()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App storage={storage} uploader={uploader} />
+    <ServicesProvider storage={storage} uploader={uploader}>
+      <App />
+    </ServicesProvider>
   </React.StrictMode>,
 )
 


### PR DESCRIPTION
## Summary
- provide storage and uploader through ServicesProvider context
- wrap app with ServicesProvider in main entry
- access services via hooks in App component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb1f6aadc8330bcf32d4f9cf4f7d4