### PR TITLE
Cache and display transcripts with offline support

### DIFF
--- a/src/components/ClipList.tsx
+++ b/src/components/ClipList.tsx
@@ -15,6 +15,7 @@ export function ClipList() {
     updateClip,
     syncQueued,
     refreshMetadata,
+    viewTranscript,
   } = useClips();
   const [search, setSearch] = useState("");
   const filtered = useMemo(() => {
@@ -181,15 +182,13 @@ export function ClipList() {
                   </button>
                 </div>
                 <div className="text-xs text-slate-500 overflow-hidden max-h-12">
-                  {c.transcriptUrl ? (
-                    <a
+                  {c.transcriptText || c.transcriptUrl || c.details ? (
+                    <button
+                      onClick={() => viewTranscript(c)}
                       className="text-slate-700 underline"
-                      href={c.transcriptUrl}
-                      target="_blank"
-                      rel="noreferrer"
                     >
                       Transcript
-                    </a>
+                    </button>
                   ) : (
                     <span className="text-slate-400">No transcript yet.</span>
                   )}

--- a/src/components/TranscriptModal.tsx
+++ b/src/components/TranscriptModal.tsx
@@ -1,0 +1,54 @@
+import { Clip } from "../models/clip";
+
+interface Props {
+  clip: Clip;
+  onClose(): void;
+}
+
+export function TranscriptModal({ clip, onClose }: Props) {
+  const text = clip.transcriptText || "";
+  function download() {
+    const blob = new Blob([text], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${clip.title || "transcript"}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+  return (
+    <div
+      className="fixed inset-0 z-20 flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded-2xl bg-white shadow-xl border border-slate-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-4 border-b border-slate-200 flex items-center justify-between">
+          <h3 className="font-semibold">Transcript</h3>
+          <button onClick={onClose} className="text-slate-500 hover:text-slate-900">
+            ✕
+          </button>
+        </div>
+        <div className="p-4 max-h-[60vh] overflow-auto whitespace-pre-wrap text-sm text-slate-800">
+          {text}
+        </div>
+        <div className="p-4 border-t border-slate-200 flex items-center justify-end gap-2">
+          <button
+            onClick={() => navigator.clipboard.writeText(text)}
+            className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+          >
+            Copy
+          </button>
+          <button
+            onClick={download}
+            className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+          >
+            Download
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/context/clips.tsx
+++ b/src/context/clips.tsx
@@ -13,6 +13,7 @@ export interface ClipsContextValue {
   updateClip(id: string, patch: Partial<Clip>): void;
   syncQueued(): void | Promise<void>;
   refreshMetadata(): void | Promise<void>;
+  viewTranscript(c: Clip): void | Promise<void>;
 }
 
 const ClipsContext = createContext<ClipsContextValue | undefined>(undefined);

--- a/src/models/clip.ts
+++ b/src/models/clip.ts
@@ -22,6 +22,7 @@ export type Clip = {
   details?: string;
   serverId?: string;
   transcriptUrl?: string;
+  transcriptText?: string;
   status: ClipStatus;
   blob?: Blob;
   objectUrl?: string;


### PR DESCRIPTION
## Summary
- store transcript text alongside clips
- fetch transcript text and fallback to details after status updates
- add in-app transcript modal with copy and download actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcc9a63fd483308277f0ad9fcfa74c