### PR TITLE
Hide upload button after clips sync

### DIFF
--- a/src/components/ClipList.tsx
+++ b/src/components/ClipList.tsx
@@ -166,13 +166,15 @@ export function ClipList() {
                       <PlayIcon /> Play
                     </button>
                   )}
-                  <button
-                    onClick={() => uploadClip(c)}
-                    disabled={c.status === "processing"}
-                    className="rounded-full bg-slate-900 text-white px-3 py-2 text-sm flex items-center gap-2 disabled:opacity-50"
-                  >
-                    <UploadIcon /> Upload
-                  </button>
+                  {c.status !== "uploaded" && (
+                    <button
+                      onClick={() => uploadClip(c)}
+                      disabled={c.status === "processing"}
+                      className="rounded-full bg-slate-900 text-white px-3 py-2 text-sm flex items-center gap-2 disabled:opacity-50"
+                    >
+                      <UploadIcon /> Upload
+                    </button>
+                  )}
                   <button
                     onClick={() => removeClip(c.id)}
                     className="rounded-full border px-3 py-2 text-sm flex items-center gap-2"


### PR DESCRIPTION
## Summary
- hide Upload button once a clip is marked as uploaded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcd20d2ea083308df30c246ab1705c