### PR TITLE
Fix mobile list item overflow

### DIFF
--- a/src/components/ClipList.tsx
+++ b/src/components/ClipList.tsx
@@ -150,7 +150,7 @@ export function ClipList() {
               </div>
 
               <div className="sm:col-span-4 flex flex-col items-stretch justify-between gap-3">
-                <div className="flex items-center justify-end gap-2">
+                <div className="flex flex-wrap items-center justify-start sm:justify-end gap-2">
                   {playingId === c.id ? (
                     <button
                     onClick={stopPlayback}


### PR DESCRIPTION
## Summary
- allow clip action buttons to wrap on small screens so recordings remain visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc1045358833095da4a95f7f86f77