### PR TITLE
feat: add fallbacks for unsupported iOS Chrome features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,7 +161,7 @@ export default function App() {
   }
 
   function addClip(clip: Clip) {
-    setClips((prev) => [clip, ...prev]);
+    setClips((prev) => (prev.some((c) => c.id === clip.id) ? prev : [clip, ...prev]));
   }
 
   const clipContextValue = {

--- a/src/components/RecorderControls.tsx
+++ b/src/components/RecorderControls.tsx
@@ -163,7 +163,6 @@ export function RecorderControls() {
   }
   function stopRecording() {
     if (!recorder) return;
-    recorder.stream.getTracks().forEach((t) => t.stop());
     recorder.stop();
     setRecorder(null);
     recordStartRef.current = null;
@@ -171,7 +170,6 @@ export function RecorderControls() {
   }
   async function cancelRecording() {
     if (!recorder) return;
-    recorder.stream.getTracks().forEach((t) => t.stop());
     if ("cancel" in recorder) (recorder as any).cancel();
     else recorder.stop();
     setRecorder(null);

--- a/src/components/RecorderControls.tsx
+++ b/src/components/RecorderControls.tsx
@@ -88,10 +88,14 @@ export function RecorderControls() {
         const objectUrl = URL.createObjectURL(blob);
         const duration = await probeDurationFromBlob(blob);
         const saved: Clip = { ...newClip, blob, objectUrl, size, duration, status: "saved" };
-        await storage.save(saved);
         addClip(saved);
         setRecordingClip(null);
         setRecordMs(0);
+        try {
+          await storage.save(saved);
+        } catch (err) {
+          console.error(err);
+        }
       } catch (e) {
         console.error(e);
         setRecordingClip((c) => (c ? { ...c, status: "error" } : c));
@@ -167,6 +171,7 @@ export function RecorderControls() {
     setRecorder(null);
     recordStartRef.current = null;
     if (timerRef.current) cancelAnimationFrame(timerRef.current);
+    setRecordMs(0);
   }
   async function cancelRecording() {
     if (!recorder) return;
@@ -176,6 +181,7 @@ export function RecorderControls() {
     setRecordingClip(null);
     recordStartRef.current = null;
     if (timerRef.current) cancelAnimationFrame(timerRef.current);
+    setRecordMs(0);
   }
 
   function probeDurationFromBlob(blob: Blob): Promise<number> {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
-import { registerSW } from 'virtual:pwa-register'
-import { IndexedDbStorage } from './services/indexed-db'
+import { createClipStore } from './services/clip-store-factory'
+import { initServiceWorker } from './services/service-worker'
 import { HttpUploader } from './services/http-uploader'
 import { ServicesProvider } from './context/services'
 
-registerSW({ immediate: true })
+initServiceWorker()
 
-const storage = new IndexedDbStorage()
+const storage = createClipStore()
 const uploader = new HttpUploader()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/services/clip-store-factory.ts
+++ b/src/services/clip-store-factory.ts
@@ -2,6 +2,7 @@ import { ClipStore } from "./types";
 import { IndexedDbStorage } from "./indexed-db";
 import { MemoryStorage } from "./memory-storage";
 import { FallbackStorage } from "./fallback-storage";
+import { LocalStorageStorage } from "./local-storage";
 
 /**
  * Create a {@link ClipStore} that attempts to use IndexedDB and falls back to
@@ -9,9 +10,17 @@ import { FallbackStorage } from "./fallback-storage";
  */
 export function createClipStore(): ClipStore {
   const memory = new MemoryStorage();
-  if (typeof indexedDB === "undefined") {
-    return memory;
+  let store: ClipStore = memory;
+
+  if (typeof localStorage !== "undefined") {
+    const local = new LocalStorageStorage();
+    store = new FallbackStorage(local, store);
   }
-  const idb = new IndexedDbStorage();
-  return new FallbackStorage(idb, memory);
+
+  if (typeof indexedDB !== "undefined") {
+    const idb = new IndexedDbStorage();
+    store = new FallbackStorage(idb, store);
+  }
+
+  return store;
 }

--- a/src/services/clip-store-factory.ts
+++ b/src/services/clip-store-factory.ts
@@ -1,0 +1,17 @@
+import { ClipStore } from "./types";
+import { IndexedDbStorage } from "./indexed-db";
+import { MemoryStorage } from "./memory-storage";
+import { FallbackStorage } from "./fallback-storage";
+
+/**
+ * Create a {@link ClipStore} that attempts to use IndexedDB and falls back to
+ * an in-memory store when IndexedDB is unavailable or throws.
+ */
+export function createClipStore(): ClipStore {
+  const memory = new MemoryStorage();
+  if (typeof indexedDB === "undefined") {
+    return memory;
+  }
+  const idb = new IndexedDbStorage();
+  return new FallbackStorage(idb, memory);
+}

--- a/src/services/fallback-storage.ts
+++ b/src/services/fallback-storage.ts
@@ -2,34 +2,56 @@ import { Clip } from "../models/clip";
 import { ClipStore } from "./types";
 
 /**
- * Wraps two {@link ClipStore} implementations and falls back to the secondary
- * store when the primary one fails. This allows graceful degradation on
- * browsers with flaky persistent storage (e.g. iOS Chrome IndexedDB).
+ * Wraps two {@link ClipStore} implementations. Writes are attempted against
+ * both stores to keep them in sync, while reads prefer the primary store and
+ * fall back to the secondary store if the primary fails or contains no data.
+ * This allows graceful degradation on browsers with flaky persistent storage
+ * (e.g. iOS Chrome IndexedDB).
  */
 export class FallbackStorage implements ClipStore {
   constructor(private primary: ClipStore, private secondary: ClipStore) {}
 
   async save(clip: Clip): Promise<void> {
+    let err: unknown;
     try {
       await this.primary.save(clip);
-    } catch {
+    } catch (e) {
+      err = e;
+    }
+    try {
       await this.secondary.save(clip);
+    } catch (e) {
+      if (!err) err = e;
+    }
+    if (err && typeof err !== 'undefined') {
+      throw err;
     }
   }
 
   async getAll(): Promise<Clip[]> {
     try {
-      return await this.primary.getAll();
+      const primary = await this.primary.getAll();
+      if (primary.length) return primary;
     } catch {
-      return await this.secondary.getAll();
+      // fall through to secondary
     }
+    return await this.secondary.getAll();
   }
 
   async remove(id: string): Promise<void> {
+    let err: unknown;
     try {
       await this.primary.remove(id);
-    } catch {
+    } catch (e) {
+      err = e;
+    }
+    try {
       await this.secondary.remove(id);
+    } catch (e) {
+      if (!err) err = e;
+    }
+    if (err && typeof err !== 'undefined') {
+      throw err;
     }
   }
 }

--- a/src/services/fallback-storage.ts
+++ b/src/services/fallback-storage.ts
@@ -1,0 +1,35 @@
+import { Clip } from "../models/clip";
+import { ClipStore } from "./types";
+
+/**
+ * Wraps two {@link ClipStore} implementations and falls back to the secondary
+ * store when the primary one fails. This allows graceful degradation on
+ * browsers with flaky persistent storage (e.g. iOS Chrome IndexedDB).
+ */
+export class FallbackStorage implements ClipStore {
+  constructor(private primary: ClipStore, private secondary: ClipStore) {}
+
+  async save(clip: Clip): Promise<void> {
+    try {
+      await this.primary.save(clip);
+    } catch {
+      await this.secondary.save(clip);
+    }
+  }
+
+  async getAll(): Promise<Clip[]> {
+    try {
+      return await this.primary.getAll();
+    } catch {
+      return await this.secondary.getAll();
+    }
+  }
+
+  async remove(id: string): Promise<void> {
+    try {
+      await this.primary.remove(id);
+    } catch {
+      await this.secondary.remove(id);
+    }
+  }
+}

--- a/src/services/local-storage.ts
+++ b/src/services/local-storage.ts
@@ -1,0 +1,57 @@
+import { Clip } from "../models/clip";
+import { ClipStore } from "./types";
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
+function dataUrlToBlob(url: string): Promise<Blob> {
+  return fetch(url).then((r) => r.blob());
+}
+
+/**
+ * Persists clips to localStorage using base64 encoding for blob data.
+ */
+export class LocalStorageStorage implements ClipStore {
+  private readonly prefix = "voiceNotes.clip.";
+
+  async save(clip: Clip): Promise<void> {
+    const { objectUrl, blob, ...rest } = clip as any;
+    const data: any = { ...rest };
+    if (blob) {
+      data.blob = await blobToDataUrl(blob);
+    }
+    localStorage.setItem(this.prefix + clip.id, JSON.stringify(data));
+  }
+
+  async getAll(): Promise<Clip[]> {
+    const clips: Clip[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key || !key.startsWith(this.prefix)) continue;
+      const raw = localStorage.getItem(key);
+      if (!raw) continue;
+      try {
+        const parsed = JSON.parse(raw);
+        const { blob: dataUrl, ...rest } = parsed;
+        let blob: Blob | undefined;
+        if (dataUrl) {
+          blob = await dataUrlToBlob(dataUrl);
+        }
+        clips.push({ ...rest, blob });
+      } catch {
+        // ignore malformed entries
+      }
+    }
+    return clips;
+  }
+
+  async remove(id: string): Promise<void> {
+    localStorage.removeItem(this.prefix + id);
+  }
+}

--- a/src/services/memory-storage.ts
+++ b/src/services/memory-storage.ts
@@ -1,0 +1,22 @@
+import { Clip } from "../models/clip";
+import { ClipStore } from "./types";
+
+/**
+ * A simple in-memory clip store used as a fallback when persistent
+ * storage (e.g. IndexedDB) is unavailable.
+ */
+export class MemoryStorage implements ClipStore {
+  private clips = new Map<string, Clip>();
+
+  async save(clip: Clip): Promise<void> {
+    this.clips.set(clip.id, clip);
+  }
+
+  async getAll(): Promise<Clip[]> {
+    return Array.from(this.clips.values());
+  }
+
+  async remove(id: string): Promise<void> {
+    this.clips.delete(id);
+  }
+}

--- a/src/services/service-worker.ts
+++ b/src/services/service-worker.ts
@@ -1,0 +1,16 @@
+/// <reference path="../vite-env.d.ts" />
+import { registerSW } from 'virtual:pwa-register';
+
+/**
+ * Register the service worker if the current browser supports it. Browsers like
+ * Chrome on iOS do not support service workers, so this safely no-ops there.
+ */
+export function initServiceWorker() {
+  if ('serviceWorker' in navigator) {
+    try {
+      registerSW({ immediate: true });
+    } catch (e) {
+      console.warn('Service worker registration failed', e);
+    }
+  }
+}

--- a/src/services/wav-recorder.ts
+++ b/src/services/wav-recorder.ts
@@ -53,7 +53,10 @@ export class WavRecorder {
     const wav = encodeWav(buffer, this.ctx.sampleRate);
     const blob = new Blob([wav], { type: 'audio/wav' });
     if (this.ondataavailable) {
-      this.ondataavailable(new BlobEvent('dataavailable', { data: blob }));
+      const event = typeof BlobEvent === 'function'
+        ? new BlobEvent('dataavailable', { data: blob })
+        : ({ data: blob } as BlobEvent);
+      this.ondataavailable(event);
     }
     if (this.onstop) this.onstop();
     this.ctx.close();

--- a/src/services/wav-recorder.ts
+++ b/src/services/wav-recorder.ts
@@ -1,0 +1,103 @@
+/**
+ * A minimal MediaRecorder-like implementation that captures audio using the
+ * Web Audio API and outputs a WAV blob. Used as a fallback on browsers without
+ * reliable MediaRecorder support (e.g. Chrome on iOS).
+ */
+export class WavRecorder {
+  stream: MediaStream;
+  state: 'inactive' | 'recording' | 'paused' = 'inactive';
+  ondataavailable: ((ev: BlobEvent) => void) | null = null;
+  onstop: (() => void) | null = null;
+
+  private ctx: AudioContext;
+  private processor: ScriptProcessorNode;
+  private chunks: Float32Array[] = [];
+
+  constructor(stream: MediaStream) {
+    this.stream = stream;
+    this.ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    const source = this.ctx.createMediaStreamSource(stream);
+    this.processor = this.ctx.createScriptProcessor(4096, 1, 1);
+    source.connect(this.processor);
+    this.processor.connect(this.ctx.destination);
+    this.processor.onaudioprocess = (e) => {
+      if (this.state === 'recording') {
+        this.chunks.push(new Float32Array(e.inputBuffer.getChannelData(0)));
+      }
+    };
+  }
+
+  start(_timeslice?: number) {
+    this.state = 'recording';
+  }
+
+  pause() {
+    this.state = 'paused';
+  }
+
+  resume() {
+    this.state = 'recording';
+  }
+
+  stop() {
+    this.state = 'inactive';
+    this.processor.disconnect();
+    this.stream.getTracks().forEach((t) => t.stop());
+    const bufferLength = this.chunks.reduce((n, c) => n + c.length, 0);
+    const buffer = new Float32Array(bufferLength);
+    let offset = 0;
+    for (const c of this.chunks) {
+      buffer.set(c, offset);
+      offset += c.length;
+    }
+    const wav = encodeWav(buffer, this.ctx.sampleRate);
+    const blob = new Blob([wav], { type: 'audio/wav' });
+    if (this.ondataavailable) {
+      this.ondataavailable(new BlobEvent('dataavailable', { data: blob }));
+    }
+    if (this.onstop) this.onstop();
+    this.ctx.close();
+  }
+
+  // Cancel without emitting data
+  cancel() {
+    this.state = 'inactive';
+    this.processor.disconnect();
+    this.stream.getTracks().forEach((t) => t.stop());
+    this.ctx.close();
+    this.chunks = [];
+  }
+}
+
+function encodeWav(samples: Float32Array, sampleRate: number): ArrayBuffer {
+  const buffer = new ArrayBuffer(44 + samples.length * 2);
+  const view = new DataView(buffer);
+  let offset = 0;
+
+  function writeString(str: string) {
+    for (let i = 0; i < str.length; i++) {
+      view.setUint8(offset + i, str.charCodeAt(i));
+    }
+    offset += str.length;
+  }
+
+  writeString('RIFF');
+  view.setUint32(offset, 36 + samples.length * 2, true); offset += 4;
+  writeString('WAVE');
+  writeString('fmt ');
+  view.setUint32(offset, 16, true); offset += 4; // PCM chunk size
+  view.setUint16(offset, 1, true); offset += 2; // format
+  view.setUint16(offset, 1, true); offset += 2; // channels
+  view.setUint32(offset, sampleRate, true); offset += 4;
+  view.setUint32(offset, sampleRate * 2, true); offset += 4; // byte rate
+  view.setUint16(offset, 2, true); offset += 2; // block align
+  view.setUint16(offset, 16, true); offset += 2; // bits per sample
+  writeString('data');
+  view.setUint32(offset, samples.length * 2, true); offset += 4;
+
+  for (let i = 0; i < samples.length; i++, offset += 2) {
+    const s = Math.max(-1, Math.min(1, samples[i]));
+    view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+  }
+  return buffer;
+}


### PR DESCRIPTION
## Summary
- add WavRecorder fallback for browsers lacking MediaRecorder
- introduce resilient clip storage with in-memory backup and guard SW registration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdca12cc60833090af3f84b5aab10e