### PR TITLE
Add theme CSS variables and semantic Tailwind colors

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,14 @@
+@import './themes.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    @apply theme-standard;
+  }
+}
 
 /* Optional: smooth fonts */
 html, body { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }

--- a/src/themes.css
+++ b/src/themes.css
@@ -1,0 +1,22 @@
+@layer base {
+  .theme-standard {
+    --color-base: #ffffff;
+    --color-primary: #1d4ed8;
+    --color-secondary: #9333ea;
+    --color-accent: #f43f5e;
+  }
+
+  .theme-dark {
+    --color-base: #0f172a;
+    --color-primary: #3b82f6;
+    --color-secondary: #a855f7;
+    --color-accent: #f43f5e;
+  }
+
+  .theme-neon {
+    --color-base: #000000;
+    --color-primary: #39ff14;
+    --color-secondary: #ff0090;
+    --color-accent: #00eaff;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,15 @@
 /** @type {import('tailwindcss').Config} */
 export default {
     content: ['./index.html', './src/**/*.{ts,tsx}'],
-    theme: { extend: {} },
+    theme: {
+        extend: {
+            colors: {
+                base: 'var(--color-base)',
+                primary: 'var(--color-primary)',
+                secondary: 'var(--color-secondary)',
+                accent: 'var(--color-accent)',
+            },
+        },
+    },
     plugins: [],
 }


### PR DESCRIPTION
## Summary
- map semantic Tailwind color names to CSS variables
- define standard, dark, and neon themes via CSS variables
- import theme definitions and set standard theme as default

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bddc9722188330898a2d36a91fe4df