### PR TITLE
refactor: use semantic theme colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -261,19 +261,19 @@ export default function App() {
   }, [clips]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-50 text-slate-900">
-      <header className="sticky top-0 z-10 backdrop-blur bg-white/70 border-b border-slate-200">
+    <div className="min-h-screen bg-gradient-to-b from-base via-base to-base text-content">
+      <header className="sticky top-0 z-10 backdrop-blur bg-base/70 border-b border-muted">
         <div className="mx-auto max-w-5xl px-4 py-3 flex items-center gap-3">
-          <div className="w-9 h-9 rounded-xl bg-slate-900 text-white flex items-center justify-center shadow">
+          <div className="w-9 h-9 rounded-xl bg-primary text-base flex items-center justify-center shadow">
             <MicIcon size={18} />
           </div>
           <div className="flex-1">
             <h1 className="text-lg font-semibold leading-tight">Velvet Notes</h1>
-            <p className="text-xs text-slate-500">Premium voice notes — record, tag, and sync</p>
+            <p className="text-xs text-muted">Premium voice notes — record, tag, and sync</p>
           </div>
           <button
             onClick={() => setShowSettings(true)}
-            className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm hover:shadow-sm"
+            className="inline-flex items-center gap-2 rounded-xl border border-muted bg-base px-3 py-2 text-sm hover:shadow-sm"
           >
             <SettingsIcon /> Settings
           </button>
@@ -292,7 +292,7 @@ export default function App() {
         <SettingsModal api={api} onApiChange={setApi} onClose={() => setShowSettings(false)} />
       )}
 
-      <footer className="py-10 text-center text-xs text-slate-400">
+      <footer className="py-10 text-center text-xs text-muted">
         Built with ❤️ — works in modern browsers. For iOS Safari, ensure you serve over HTTPS and
         tap to start recording.
       </footer>

--- a/src/components/ClipList.tsx
+++ b/src/components/ClipList.tsx
@@ -33,29 +33,29 @@ export function ClipList() {
         <div className="flex-1">
           <div className="relative">
             <input
-              className="w-full rounded-xl border border-slate-200 bg-white px-4 py-2 pr-10 text-sm"
+              className="w-full rounded-xl border border-muted bg-base px-4 py-2 pr-10 text-sm"
               placeholder="Search title, tags, details…"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
             />
-            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 text-xs">/</span>
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-muted text-xs">/</span>
           </div>
         </div>
         <span
-          className={`rounded-xl px-3 py-2 text-xs border ${online ? "bg-emerald-50 text-emerald-700 border-emerald-200" : "bg-amber-50 text-amber-700 border-amber-200"}`}
+          className={`rounded-xl px-3 py-2 text-xs border ${online ? "bg-secondary/10 text-secondary border-secondary" : "bg-accent/10 text-accent border-accent"}`}
         >
           {online ? "Online" : "Offline"}
         </span>
         <button
           onClick={syncQueued}
-          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm hover:shadow-sm"
+          className="inline-flex items-center gap-2 rounded-xl border border-muted bg-base px-3 py-2 text-sm hover:shadow-sm"
           title="Upload any notes queued while offline"
         >
           Sync queued
         </button>
         <button
           onClick={refreshMetadata}
-          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm hover:shadow-sm"
+          className="inline-flex items-center gap-2 rounded-xl border border-muted bg-base px-3 py-2 text-sm hover:shadow-sm"
           title="Pull latest tags/titles from server"
         >
           Refresh
@@ -67,7 +67,7 @@ export function ClipList() {
               await uploadClip(c);
             }
           }}
-          className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm hover:shadow-sm"
+          className="inline-flex items-center gap-2 rounded-xl border border-muted bg-base px-3 py-2 text-sm hover:shadow-sm"
         >
           Upload all
         </button>
@@ -75,48 +75,48 @@ export function ClipList() {
 
       <section className="mt-4 grid grid-cols-1 gap-4">
         {filtered.length === 0 && (
-          <div className="text-center text-slate-500 text-sm py-8">No recordings yet.</div>
+          <div className="text-center text-muted text-sm py-8">No recordings yet.</div>
         )}
         {filtered.map((c) => (
           <article
             key={c.id}
-            className="rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden"
+            className="rounded-2xl border border-muted bg-base shadow-sm overflow-hidden"
           >
             <div className="p-4 sm:p-6 grid grid-cols-1 sm:grid-cols-12 gap-4">
               <div className="sm:col-span-8 flex flex-col gap-2 min-w-0">
                 <div className="flex items-center gap-2">
                   <input
-                    className="min-w-0 flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium"
+                    className="min-w-0 flex-1 rounded-lg border border-muted bg-base px-3 py-2 text-sm font-medium"
                     value={c.title || "Untitled note"}
                     onChange={(e) => updateClip(c.id, { title: e.target.value })}
                   />
-                  <span className="text-xs text-slate-500 whitespace-nowrap">
+                  <span className="text-xs text-muted whitespace-nowrap">
                     {fmt.date(c.createdAt)}
                   </span>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
-                  <div className="text-xs text-slate-500">
+                  <div className="text-xs text-muted">
                     {c.mimeType.replace("audio/", "").toUpperCase()} • {c.duration ? `${c.duration.toFixed(1)}s` : "--"} • {c.size ? `${(c.size / 1024).toFixed(0)} KB` : "--"}
                   </div>
                   {c.status === "uploaded" && (
-                    <span className="text-xs rounded-full bg-emerald-50 text-emerald-700 px-2 py-0.5">
+                    <span className="text-xs rounded-full bg-secondary/10 text-secondary px-2 py-0.5">
                       Synced
                     </span>
                   )}
                   {c.status === "processing" && (
-                    <span className="text-xs rounded-full bg-amber-50 text-amber-700 px-2 py-0.5">
+                    <span className="text-xs rounded-full bg-accent/10 text-accent px-2 py-0.5">
                       Uploading…
                     </span>
                   )}
                   {c.status === "error" && (
-                    <span className="text-xs rounded-full bg-rose-50 text-rose-700 px-2 py-0.5">
+                    <span className="text-xs rounded-full bg-accent/10 text-accent px-2 py-0.5">
                       Error
                     </span>
                   )}
                 </div>
                 <div>
                   <textarea
-                    className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm"
+                    className="w-full rounded-lg border border-muted bg-base px-3 py-2 text-sm"
                     placeholder="Details (will be enhanced by server on upload)…"
                     rows={c.details ? 3 : 2}
                     value={c.details || ""}
@@ -124,19 +124,19 @@ export function ClipList() {
                   />
                 </div>
                 <div className="flex items-center gap-2 flex-wrap">
-                  <div className="flex items-center gap-1 text-xs text-slate-500">
+                  <div className="flex items-center gap-1 text-xs text-muted">
                     <TagIcon /> Tags:
                   </div>
                   {(c.tags || []).map((t, idx) => (
                     <span
                       key={t + idx}
-                      className="rounded-full bg-slate-100 text-slate-700 px-2 py-0.5 text-xs"
+                      className="rounded-full bg-muted text-content px-2 py-0.5 text-xs"
                     >
                       {t}
                     </span>
                   ))}
                   <input
-                    className="rounded-lg border border-slate-200 bg-white px-2 py-1 text-xs"
+                    className="rounded-lg border border-muted bg-base px-2 py-1 text-xs"
                     placeholder="Add tag and press Enter"
                     onKeyDown={(e) => {
                       if (e.key === "Enter") {
@@ -170,7 +170,7 @@ export function ClipList() {
                     <button
                       onClick={() => uploadClip(c)}
                       disabled={c.status === "processing"}
-                      className="rounded-full bg-slate-900 text-white px-3 py-2 text-sm flex items-center gap-2 disabled:opacity-50"
+                      className="rounded-full bg-primary text-base px-3 py-2 text-sm flex items-center gap-2 disabled:opacity-50"
                     >
                       <UploadIcon /> Upload
                     </button>
@@ -182,10 +182,10 @@ export function ClipList() {
                     <TrashIcon /> Delete
                   </button>
                 </div>
-                <div className="text-xs text-slate-500 overflow-hidden max-h-12">
+                <div className="text-xs text-muted overflow-hidden max-h-12">
                   {c.transcriptUrl ? (
                     <a
-                      className="text-slate-700 underline"
+                      className="text-content underline"
                       href={c.transcriptUrl}
                       target="_blank"
                       rel="noreferrer"
@@ -193,7 +193,7 @@ export function ClipList() {
                       Transcript
                     </a>
                   ) : (
-                    <span className="text-slate-400">No transcript yet.</span>
+                    <span className="text-muted">No transcript yet.</span>
                   )}
                 </div>
               </div>

--- a/src/components/RecorderControls.tsx
+++ b/src/components/RecorderControls.tsx
@@ -188,12 +188,12 @@ export function RecorderControls() {
   const isRecording = recorder && ["recording", "paused"].includes(recorder.state);
 
   return (
-    <section className="rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+    <section className="rounded-2xl border border-muted bg-base shadow-sm overflow-hidden">
       <div className="p-4 sm:p-6 flex flex-col gap-4">
         <div className="flex flex-col sm:flex-row sm:items-center gap-3">
           <div className="flex-1 min-w-0">
             <h2 className="text-base font-semibold">New recording</h2>
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-muted">
               Tap to start. Works best over HTTPS and with a user gesture.
             </p>
           </div>
@@ -201,7 +201,7 @@ export function RecorderControls() {
             {!isRecording && (
               <button
                 onClick={startRecording}
-                className="inline-flex items-center gap-2 rounded-full bg-slate-900 text-white px-5 py-3 text-sm shadow hover:opacity-95"
+                className="inline-flex items-center gap-2 rounded-full bg-primary text-base px-5 py-3 text-sm shadow hover:opacity-95"
               >
                 <MicIcon /> Start
               </button>
@@ -210,19 +210,19 @@ export function RecorderControls() {
               <>
                 <button
                   onClick={pauseRecording}
-                  className="rounded-full border px-4 py-2 text-sm flex items-center gap-2"
+                  className="rounded-full border border-muted px-4 py-2 text-sm flex items-center gap-2"
                 >
                   <PauseIcon /> Pause
                 </button>
                 <button
                   onClick={stopRecording}
-                  className="rounded-full bg-emerald-600 text-white px-4 py-2 text-sm flex items-center gap-2"
+                  className="rounded-full bg-secondary text-base px-4 py-2 text-sm flex items-center gap-2"
                 >
                   <StopIcon /> Stop & Save
                 </button>
                 <button
                   onClick={cancelRecording}
-                  className="rounded-full border px-4 py-2 text-sm"
+                  className="rounded-full border border-muted px-4 py-2 text-sm"
                 >
                   Cancel
                 </button>
@@ -232,19 +232,19 @@ export function RecorderControls() {
               <>
                 <button
                   onClick={resumeRecording}
-                  className="rounded-full bg-slate-900 text-white px-4 py-2 text-sm flex items-center gap-2"
+                  className="rounded-full bg-primary text-base px-4 py-2 text-sm flex items-center gap-2"
                 >
                   <PlayIcon /> Resume
                 </button>
                 <button
                   onClick={stopRecording}
-                  className="rounded-full bg-emerald-600 text-white px-4 py-2 text-sm flex items-center gap-2"
+                  className="rounded-full bg-secondary text-base px-4 py-2 text-sm flex items-center gap-2"
                 >
                   <StopIcon /> Stop & Save
                 </button>
                 <button
                   onClick={cancelRecording}
-                  className="rounded-full border px-4 py-2 text-sm"
+                  className="rounded-full border border-muted px-4 py-2 text-sm"
                 >
                   Cancel
                 </button>
@@ -255,15 +255,15 @@ export function RecorderControls() {
 
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 items-center">
           <div className="sm:col-span-2">
-            <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+            <div className="rounded-xl border border-muted bg-base p-3">
               <canvas ref={canvasRef} className="w-full h-24" width={800} height={96} />
             </div>
           </div>
           <div className="text-center">
             <div className="text-2xl font-mono tabular-nums">{fmt.ms(recordMs)}</div>
-            <div className="text-xs text-slate-500">current session</div>
+            <div className="text-xs text-muted">current session</div>
             {permission === "denied" && (
-              <div className="mt-2 text-xs text-red-600">
+              <div className="mt-2 text-xs text-accent">
                 Microphone permission denied. Enable it in your browser settings.
               </div>
             )}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -11,42 +11,42 @@ interface SettingsModalProps {
 export function SettingsModal({ api, onApiChange, onClose }: SettingsModalProps) {
   return (
     <div
-      className="fixed inset-0 z-20 flex items-center justify-center bg-black/40 p-4"
+      className="fixed inset-0 z-20 flex items-center justify-center bg-base/40 p-4"
       onClick={onClose}
     >
       <div
-        className="w-full max-w-lg rounded-2xl bg-white shadow-xl border border-slate-200"
+        className="w-full max-w-lg rounded-2xl bg-base shadow-xl border border-muted"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="p-4 border-b border-slate-200 flex items-center justify-between">
+        <div className="p-4 border-b border-muted flex items-center justify-between">
           <h3 className="font-semibold">Connection</h3>
-          <button onClick={onClose} className="text-slate-500 hover:text-slate-900">
+          <button onClick={onClose} className="text-muted hover:text-content">
             ✕
           </button>
         </div>
         <div className="p-4 space-y-3">
           <div>
-            <label className="text-xs text-slate-500">Base URL</label>
+            <label className="text-xs text-muted">Base URL</label>
             <input
-              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+              className="w-full rounded-xl border border-muted bg-base px-3 py-2 text-sm"
               placeholder="https://api.example.com"
               value={api.baseUrl}
               onChange={(e) => onApiChange((x) => ({ ...x, baseUrl: e.target.value }))}
             />
           </div>
           <div>
-            <label className="text-xs text-slate-500">Upload Path</label>
+            <label className="text-xs text-muted">Upload Path</label>
             <input
-              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+              className="w-full rounded-xl border border-muted bg-base px-3 py-2 text-sm"
               placeholder="/notes"
               value={api.uploadPath}
               onChange={(e) => onApiChange((x) => ({ ...x, uploadPath: e.target.value }))}
             />
           </div>
           <div>
-            <label className="text-xs text-slate-500">Auth Token (optional)</label>
+            <label className="text-xs text-muted">Auth Token (optional)</label>
             <input
-              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+              className="w-full rounded-xl border border-muted bg-base px-3 py-2 text-sm"
               placeholder="Bearer token"
               value={api.authToken || ""}
               onChange={(e) => onApiChange((x) => ({ ...x, authToken: e.target.value }))}
@@ -55,7 +55,7 @@ export function SettingsModal({ api, onApiChange, onClose }: SettingsModalProps)
           <div className="pt-2 flex items-center gap-2">
             <button
               onClick={onClose}
-              className="inline-flex items-center gap-2 rounded-xl bg-slate-900 text-white px-4 py-2 text-sm"
+              className="inline-flex items-center gap-2 rounded-xl bg-primary text-base px-4 py-2 text-sm"
             >
               <SaveIcon /> Save
             </button>
@@ -68,12 +68,12 @@ export function SettingsModal({ api, onApiChange, onClose }: SettingsModalProps)
                   alert(e.message || String(e));
                 }
               }}
-              className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm"
+              className="inline-flex items-center gap-2 rounded-xl border border-muted bg-base px-4 py-2 text-sm"
             >
               Test endpoint
             </button>
           </div>
-          <div className="text-xs text-slate-500 pt-2">
+          <div className="text-xs text-muted pt-2">
             Your settings are saved locally (localStorage). Recordings are stored on-device using IndexedDB until you upload them.
           </div>
         </div>

--- a/src/themes.css
+++ b/src/themes.css
@@ -1,6 +1,8 @@
 @layer base {
   .theme-standard {
     --color-base: #ffffff;
+    --color-content: #0f172a;
+    --color-muted: #e2e8f0;
     --color-primary: #1d4ed8;
     --color-secondary: #9333ea;
     --color-accent: #f43f5e;
@@ -8,6 +10,8 @@
 
   .theme-dark {
     --color-base: #0f172a;
+    --color-content: #f8fafc;
+    --color-muted: #334155;
     --color-primary: #3b82f6;
     --color-secondary: #a855f7;
     --color-accent: #f43f5e;
@@ -15,6 +19,8 @@
 
   .theme-neon {
     --color-base: #000000;
+    --color-content: #ffffff;
+    --color-muted: #333333;
     --color-primary: #39ff14;
     --color-secondary: #ff0090;
     --color-accent: #00eaff;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,8 @@ export default {
         extend: {
             colors: {
                 base: 'var(--color-base)',
+                content: 'var(--color-content)',
+                muted: 'var(--color-muted)',
                 primary: 'var(--color-primary)',
                 secondary: 'var(--color-secondary)',
                 accent: 'var(--color-accent)',


### PR DESCRIPTION
## Summary
- use semantic Tailwind color utilities and CSS variables
- adjust components to rely on new theme colors and variables
- ensure theme builds for dark and neon modes

## Testing
- `npm test`
- `npm run build` (theme-dark)
- `npm run build` (theme-neon)


------
https://chatgpt.com/codex/tasks/task_e_68bddee640148330aee8041002c6e27b