### PR TITLE
feat: add theme provider

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,16 @@
   <link rel="apple-touch-icon" href="icons/apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-  <meta name="theme-color" content="#0f172a" />
-
+  <meta name="theme-color" content="#ffffff" />
+  <script>
+    (function () {
+      const theme = localStorage.getItem('theme') || 'standard';
+      const colors = { standard: '#ffffff', dark: '#0f172a', neon: '#000000' };
+      document.documentElement.classList.add('theme-' + theme);
+      const meta = document.querySelector('meta[name="theme-color"]');
+      if (meta) meta.setAttribute('content', colors[theme]);
+    })();
+  </script>
 
   <title>Velvet Notes</title>
 </head>

--- a/src/context/theme.tsx
+++ b/src/context/theme.tsx
@@ -1,0 +1,49 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'standard' | 'dark' | 'neon';
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme(theme: Theme): void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const THEMES: Theme[] = ['standard', 'dark', 'neon'];
+const THEME_COLORS: Record<Theme, string> = {
+  standard: '#ffffff',
+  dark: '#0f172a',
+  neon: '#000000',
+};
+
+function applyTheme(theme: Theme): void {
+  const root = document.documentElement;
+  for (const t of THEMES) root.classList.remove(`theme-${t}`);
+  root.classList.add(`theme-${theme}`);
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta) meta.setAttribute('content', THEME_COLORS[theme]);
+}
+
+export function ThemeProvider({ children }: React.PropsWithChildren) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem('theme');
+    return THEMES.includes(stored as Theme) ? (stored as Theme) : 'standard';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('theme', theme);
+    applyTheme(theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within a ThemeProvider');
+  return ctx;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { registerSW } from 'virtual:pwa-register'
 import { IndexedDbStorage } from './services/indexed-db'
 import { HttpUploader } from './services/http-uploader'
 import { ServicesProvider } from './context/services'
+import { ThemeProvider } from './context/theme'
 
 registerSW({ immediate: true })
 
@@ -15,7 +16,9 @@ const uploader = new HttpUploader()
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ServicesProvider storage={storage} uploader={uploader}>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </ServicesProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add ThemeProvider and useTheme hook to manage theme with localStorage and html classes
- wrap application with ThemeProvider
- update index.html script to sync meta theme-color with selected theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde2c6ebec8330bde5bdfadb93ba40