### PR TITLE
feat: show offline banner and split clip list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { ApiConfig } from "./services/types";
 import { useStorage, useUploader } from "./context/services";
-import { ClipsProvider } from "./context/clips";
+import { ClipsProvider, useClips } from "./context/clips";
 import { useClipManager } from "./services/clip-manager";
 import { MainApp } from "./MainApp";
 
@@ -23,8 +23,19 @@ export default function App() {
 
   return (
     <ClipsProvider value={clipManager}>
+      <OfflineBanner />
       <MainApp api={api} onApiChange={setApi} />
     </ClipsProvider>
+  );
+}
+
+function OfflineBanner() {
+  const { online } = useClips();
+  if (online) return null;
+  return (
+    <div className="bg-warning/10 text-warning text-center py-2 text-sm border-b border-warning">
+      Working offline
+    </div>
   );
 }
 

--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -13,7 +13,6 @@ import { ApiConfig } from "./services/types";
 export function MainApp({ api, onApiChange }: { api: ApiConfig, onApiChange: (api: ApiConfig) => void }) {
   const [showSettings, setShowSettings] = useState(false);
   const [showPostRecordingModal, setShowPostRecordingModal] = useState(false);
-  const [tab, setTab] = useState<"pending" | "processed">("processed");
   const clipManager = useClips();
 
   const {
@@ -36,15 +35,10 @@ export function MainApp({ api, onApiChange }: { api: ApiConfig, onApiChange: (ap
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-base via-base to-base text-content">
-      <Header
-        onSettingsClick={() => setShowSettings(true)}
-        tab={tab}
-        onTabChange={setTab}
-      />
+      <Header onSettingsClick={() => setShowSettings(true)} />
 
       <main className="mx-auto max-w-5xl px-4 py-6 pb-48">
-        {tab === "pending" && <ClipList statuses={["recording", "saved", "uploading", "error"]} />}
-        {tab === "processed" && <ClipList statuses={["uploaded"]} />}
+        <ClipList />
         <audio ref={clipManager.audioRef} className="hidden" />
       </main>
 

--- a/src/components/ClipList.tsx
+++ b/src/components/ClipList.tsx
@@ -1,13 +1,13 @@
 import { useMemo, useState } from "react";
+import type { Clip } from "../models/clip";
 import { PlayIcon, StopIcon, UploadIcon, TrashIcon, TagIcon } from "../icons";
 import { fmt } from "../utils/fmt";
 import { useClips } from "../context/clips";
 
-export function ClipList({ statuses }: { statuses: Clip["status"][] }) {
+export function ClipList() {
   const {
     clips,
     playingId,
-    online,
     playClip,
     stopPlayback,
     uploadClip,
@@ -16,17 +16,145 @@ export function ClipList({ statuses }: { statuses: Clip["status"][] }) {
     syncQueued,
     refreshMetadata,
   } = useClips();
+
   const [search, setSearch] = useState("");
+
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase();
-    const filteredByStatus = clips.filter((c) => statuses.includes(c.status));
-    if (!q) return filteredByStatus;
-    return filteredByStatus.filter((c) =>
+    if (!q) return clips;
+    return clips.filter((c) =>
       [c.title, c.details, ...(c.tags || [])]
         .filter(Boolean)
         .some((v) => String(v).toLowerCase().includes(q))
     );
-  }, [search, clips, statuses]);
+  }, [search, clips]);
+
+  const unprocessed = filtered.filter((c) => c.status !== "uploaded");
+  const processed = filtered.filter((c) => c.status === "uploaded");
+
+  const renderClip = (c: Clip) => (
+    <article
+      key={c.id}
+      className="rounded-2xl border border-subtle bg-surface shadow-sm overflow-hidden"
+    >
+      <div className="p-4 sm:p-6 grid grid-cols-1 sm:grid-cols-12 gap-4">
+        <div className="sm:col-span-8 flex flex-col gap-2 min-w-0">
+          <div className="flex items-center gap-2">
+            <input
+              className="min-w-0 flex-1 rounded-lg border border-subtle bg-surface px-3 py-2 text-sm font-medium"
+              value={c.title || "Untitled note"}
+              onChange={(e) => updateClip(c.id, { title: e.target.value })}
+            />
+            <span className="text-xs text-muted whitespace-nowrap">
+              {fmt.date(c.createdAt)}
+            </span>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="text-xs text-muted">
+              {c.mimeType.replace("audio/", "").toUpperCase()} • {c.duration ? `${c.duration.toFixed(1)}s` : "--"} • {c.size ? `${(c.size / 1024).toFixed(0)} KB` : "--"}
+            </div>
+            {c.status === "uploaded" && (
+              <span className="text-xs rounded-full bg-success/10 text-success px-2 py-0.5">
+                Synced
+              </span>
+            )}
+            {c.status === "processing" && (
+              <span className="text-xs rounded-full bg-secondary/10 text-secondary px-2 py-0.5">
+                Uploading…
+              </span>
+            )}
+            {c.status === "error" && (
+              <span className="text-xs rounded-full bg-accent/10 text-accent px-2 py-0.5">
+                Error
+              </span>
+            )}
+          </div>
+          <div>
+            <textarea
+              className="w-full rounded-lg border border-subtle bg-surface px-3 py-2 text-sm"
+              placeholder="Details (will be enhanced by server on upload)…"
+              rows={c.details ? 3 : 2}
+              value={c.details || ""}
+              onChange={(e) => updateClip(c.id, { details: e.target.value })}
+            />
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <div className="flex items-center gap-1 text-xs text-muted">
+              <TagIcon /> Tags:
+            </div>
+            {(c.tags || []).map((t, idx) => (
+              <span
+                key={t + idx}
+                className="rounded-full bg-subtle text-content px-2 py-0.5 text-xs"
+              >
+                {t}
+              </span>
+            ))}
+            <input
+              className="rounded-lg border border-subtle bg-surface px-2 py-1 text-xs"
+              placeholder="Add tag and press Enter"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  const val = (e.target as HTMLInputElement).value.trim();
+                  if (val) updateClip(c.id, { tags: [...(c.tags || []), val] });
+                  (e.target as HTMLInputElement).value = "";
+                }
+              }}
+            />
+          </div>
+        </div>
+
+        <div className="sm:col-span-4 flex flex-col items-stretch justify-between gap-3">
+          <div className="flex items-center justify-end gap-2">
+            {playingId === c.id ? (
+              <button
+                onClick={stopPlayback}
+                className="rounded-full border px-3 py-2 text-sm flex items-center gap-2"
+              >
+                <StopIcon /> Stop
+              </button>
+            ) : (
+              <button
+                onClick={() => playClip(c)}
+                className="rounded-full border px-3 py-2 text-sm flex items-center gap-2"
+              >
+                <PlayIcon /> Play
+              </button>
+            )}
+            {c.status !== "uploaded" && (
+              <button
+                onClick={() => uploadClip(c)}
+                disabled={c.status === "processing"}
+                className="rounded-full bg-primary text-base px-3 py-2 text-sm flex items-center gap-2 disabled:opacity-50"
+              >
+                <UploadIcon /> Upload
+              </button>
+            )}
+            <button
+              onClick={() => removeClip(c.id)}
+              className="rounded-full border px-3 py-2 text-sm flex items-center gap-2"
+            >
+              <TrashIcon /> Delete
+            </button>
+          </div>
+          <div className="text-xs text-muted overflow-hidden max-h-12">
+            {c.transcriptUrl ? (
+              <a
+                className="text-content underline"
+                href={c.transcriptUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Transcript
+              </a>
+            ) : (
+              <span className="text-muted">No transcript yet.</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
 
   return (
     <>
@@ -42,11 +170,6 @@ export function ClipList({ statuses }: { statuses: Clip["status"][] }) {
             <span className="absolute right-3 top-1/2 -translate-y-1/2 text-muted text-xs">/</span>
           </div>
         </div>
-        <span
-          className={`rounded-xl px-3 py-2 text-xs border ${online ? "bg-success/10 text-success border-success" : "bg-warning/10 text-warning border-warning"}`}
-        >
-          {online ? "Online" : "Offline"}
-        </span>
         <button
           onClick={syncQueued}
           className="inline-flex items-center gap-2 rounded-xl border border-subtle bg-surface px-3 py-2 text-sm hover:shadow-sm"
@@ -74,134 +197,28 @@ export function ClipList({ statuses }: { statuses: Clip["status"][] }) {
         </button>
       </div>
 
-      <section className="mt-4 grid grid-cols-1 gap-4">
-        {filtered.length === 0 && (
-          <div className="text-center text-muted text-sm py-8">No recordings yet.</div>
-        )}
-        {filtered.map((c) => (
-          <article
-            key={c.id}
-            className="rounded-2xl border border-subtle bg-surface shadow-sm overflow-hidden"
-          >
-            <div className="p-4 sm:p-6 grid grid-cols-1 sm:grid-cols-12 gap-4">
-              <div className="sm:col-span-8 flex flex-col gap-2 min-w-0">
-                <div className="flex items-center gap-2">
-                  <input
-                    className="min-w-0 flex-1 rounded-lg border border-subtle bg-surface px-3 py-2 text-sm font-medium"
-                    value={c.title || "Untitled note"}
-                    onChange={(e) => updateClip(c.id, { title: e.target.value })}
-                  />
-                  <span className="text-xs text-muted whitespace-nowrap">
-                    {fmt.date(c.createdAt)}
-                  </span>
-                </div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <div className="text-xs text-muted">
-                    {c.mimeType.replace("audio/", "").toUpperCase()} • {c.duration ? `${c.duration.toFixed(1)}s` : "--"} • {c.size ? `${(c.size / 1024).toFixed(0)} KB` : "--"}
-                  </div>
-                  {c.status === "uploaded" && (
-                    <span className="text-xs rounded-full bg-success/10 text-success px-2 py-0.5">
-                      Synced
-                    </span>
-                  )}
-                  {c.status === "processing" && (
-                    <span className="text-xs rounded-full bg-secondary/10 text-secondary px-2 py-0.5">
-                      Uploading…
-                    </span>
-                  )}
-                  {c.status === "error" && (
-                    <span className="text-xs rounded-full bg-accent/10 text-accent px-2 py-0.5">
-                      Error
-                    </span>
-                  )}
-                </div>
-                <div>
-                  <textarea
-                    className="w-full rounded-lg border border-subtle bg-surface px-3 py-2 text-sm"
-                    placeholder="Details (will be enhanced by server on upload)…"
-                    rows={c.details ? 3 : 2}
-                    value={c.details || ""}
-                    onChange={(e) => updateClip(c.id, { details: e.target.value })}
-                  />
-                </div>
-                <div className="flex items-center gap-2 flex-wrap">
-                  <div className="flex items-center gap-1 text-xs text-muted">
-                    <TagIcon /> Tags:
-                  </div>
-                  {(c.tags || []).map((t, idx) => (
-                    <span
-                      key={t + idx}
-                      className="rounded-full bg-subtle text-content px-2 py-0.5 text-xs"
-                    >
-                      {t}
-                    </span>
-                  ))}
-                  <input
-                    className="rounded-lg border border-subtle bg-surface px-2 py-1 text-xs"
-                    placeholder="Add tag and press Enter"
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        const val = (e.target as HTMLInputElement).value.trim();
-                        if (val) updateClip(c.id, { tags: [...(c.tags || []), val] });
-                        (e.target as HTMLInputElement).value = "";
-                      }
-                    }}
-                  />
-                </div>
-              </div>
+      {unprocessed.length === 0 && processed.length === 0 && (
+        <div className="text-center text-muted text-sm py-8">No recordings yet.</div>
+      )}
 
-              <div className="sm:col-span-4 flex flex-col items-stretch justify-between gap-3">
-                <div className="flex items-center justify-end gap-2">
-                  {playingId === c.id ? (
-                    <button
-                    onClick={stopPlayback}
-                      className="rounded-full border px-3 py-2 text-sm flex items-center gap-2"
-                    >
-                      <StopIcon /> Stop
-                    </button>
-                  ) : (
-                    <button
-                      onClick={() => playClip(c)}
-                      className="rounded-full border px-3 py-2 text-sm flex items-center gap-2"
-                    >
-                      <PlayIcon /> Play
-                    </button>
-                  )}
-                  {c.status !== "uploaded" && (
-                    <button
-                      onClick={() => uploadClip(c)}
-                      disabled={c.status === "processing"}
-                      className="rounded-full bg-primary text-base px-3 py-2 text-sm flex items-center gap-2 disabled:opacity-50"
-                    >
-                      <UploadIcon /> Upload
-                    </button>
-                  )}
-                  <button
-                    onClick={() => removeClip(c.id)}
-                    className="rounded-full border px-3 py-2 text-sm flex items-center gap-2"
-                  >
-                    <TrashIcon /> Delete
-                  </button>
-                </div>
-                <div className="text-xs text-muted overflow-hidden max-h-12">
-                  {c.transcriptUrl ? (
-                    <a
-                      className="text-content underline"
-                      href={c.transcriptUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Transcript
-                    </a>
-                  ) : (
-                    <span className="text-muted">No transcript yet.</span>
-                  )}
-                </div>
-              </div>
-            </div>
-          </article>
-        ))}
-      </section>
+      {unprocessed.length > 0 && (
+        <>
+          <h2 className="mt-4 text-lg font-semibold">Unprocessed</h2>
+          <section className="mt-4 grid grid-cols-1 gap-4">
+            {unprocessed.map(renderClip)}
+          </section>
+        </>
+      )}
+
+      {processed.length > 0 && (
+        <>
+          <h2 className="mt-8 text-lg font-semibold">Processed</h2>
+          <section className="mt-4 grid grid-cols-1 gap-4">
+            {processed.map(renderClip)}
+          </section>
+        </>
+      )}
     </>
   );
 }
+

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,11 +3,9 @@ import { SettingsIcon } from "../icons";
 
 type HeaderProps = {
   onSettingsClick: () => void;
-  tab: "pending" | "processed";
-  onTabChange: (tab: "pending" | "processed") => void;
 };
 
-export function Header({ onSettingsClick, tab, onTabChange }: HeaderProps) {
+export function Header({ onSettingsClick }: HeaderProps) {
   const { theme } = useTheme();
 
   let effectiveTheme = theme;
@@ -37,20 +35,6 @@ export function Header({ onSettingsClick, tab, onTabChange }: HeaderProps) {
           <SettingsIcon />
           <span className="hidden sm:inline">Settings</span>
         </button>
-      </div>
-      <div className="mx-auto max-w-5xl px-4">
-        <div className="flex gap-4 border-b border-subtle">
-          <button
-            onClick={() => onTabChange("pending")}
-            className={`py-2 px-4 text-sm ${tab === "pending" ? "border-b-2 border-primary text-primary" : "text-muted"}`}>
-            Pending
-          </button>
-          <button
-            onClick={() => onTabChange("processed")}
-            className={`py-2 px-4 text-sm ${tab === "processed" ? "border-b-2 border-primary text-primary" : "text-muted"}`}>
-            Processed
-          </button>
-        </div>
       </div>
     </header>
   );

--- a/src/context/clips.tsx
+++ b/src/context/clips.tsx
@@ -5,6 +5,7 @@ export interface ClipsContextValue {
   clips: Clip[];
   playingId: string | null;
   online: boolean;
+  audioRef: React.RefObject<HTMLAudioElement>;
   addClip(clip: Clip): void;
   playClip(c: Clip): void | Promise<void>;
   stopPlayback(): void;


### PR DESCRIPTION
## Summary
- remove online/offline badge and split clip list into unprocessed vs processed
- show offline banner when clips are not online
- simplify header and render clip list in a single page

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*


------
https://chatgpt.com/codex/tasks/task_e_68bf54aed4ac8330ba64ba148c267a8c