### PR TITLE
Add Supabase login flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@supabase/supabase-js": "^2.45.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,22 @@ export default function App() {
   }, [api.baseUrl, api.uploadPath]);
 
   useEffect(() => {
+    async function handleAuthCallback() {
+      const hash = window.location.hash;
+      const search = window.location.search;
+      if (hash.includes("access_token") || search.includes("code=")) {
+        const { data, error } = await supabase.auth.getSessionFromUrl({ storeSession: true });
+        if (!error && data.session) {
+          setApi((prev) => ({ ...prev, authToken: data.session.access_token || "" }));
+        }
+        const path = window.location.pathname === "/auth/callback" ? "/" : window.location.pathname;
+        window.history.replaceState({}, "", path);
+      }
+    }
+    handleAuthCallback();
+  }, []);
+
+  useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       setApi((prev) => ({ ...prev, authToken: session?.access_token || "" }));
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,8 +36,11 @@ export default function App() {
   }, []);
 
   const clipManager = useClipManager(api, storage, uploader);
+  const isAuthCallback =
+    window.location.pathname === "/auth/callback" ||
+    window.location.hash.includes("access_token");
 
-  if (window.location.pathname === "/auth/callback") {
+  if (isAuthCallback) {
     return <AuthCallback />;
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
+import { supabase } from "./utils/supabase";
 import type { ApiConfig } from "./services/types";
 import { useStorage, useUploader } from "./context/services";
 import { ClipsProvider } from "./context/clips";
 import { useClipManager } from "./services/clip-manager";
 import { MainApp } from "./MainApp";
+import { LoginScreen } from "./components/LoginScreen";
 
 export default function App() {
   const storage = useStorage();
@@ -11,15 +13,32 @@ export default function App() {
   const [api, setApi] = useState<ApiConfig>(() => {
     const saved = localStorage.getItem("voiceNotes.api");
     return saved
-      ? JSON.parse(saved)
+      ? { ...JSON.parse(saved), authToken: "" }
       : { baseUrl: "https://api.example.com", uploadPath: "/notes", authToken: "" };
   });
 
   useEffect(() => {
-    localStorage.setItem("voiceNotes.api", JSON.stringify(api));
-  }, [api]);
+    const { authToken, ...persisted } = api;
+    localStorage.setItem("voiceNotes.api", JSON.stringify(persisted));
+  }, [api.baseUrl, api.uploadPath]);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setApi((prev) => ({ ...prev, authToken: session?.access_token || "" }));
+    });
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      setApi((prev) => ({ ...prev, authToken: session?.access_token || "" }));
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
 
   const clipManager = useClipManager(api, storage, uploader);
+
+  if (!api.authToken) {
+    return <LoginScreen onLogin={(token) => setApi({ ...api, authToken: token })} />;
+  }
 
   return (
     <ClipsProvider value={clipManager}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { ClipsProvider } from "./context/clips";
 import { useClipManager } from "./services/clip-manager";
 import { MainApp } from "./MainApp";
 import { LoginScreen } from "./components/LoginScreen";
+import { AuthCallback } from "./components/AuthCallback";
 
 export default function App() {
   const storage = useStorage();
@@ -23,22 +24,6 @@ export default function App() {
   }, [api.baseUrl, api.uploadPath]);
 
   useEffect(() => {
-    async function handleAuthCallback() {
-      const hash = window.location.hash;
-      const search = window.location.search;
-      if (hash.includes("access_token") || search.includes("code=")) {
-        const { data, error } = await supabase.auth.getSessionFromUrl({ storeSession: true });
-        if (!error && data.session) {
-          setApi((prev) => ({ ...prev, authToken: data.session.access_token || "" }));
-        }
-        const path = window.location.pathname === "/auth/callback" ? "/" : window.location.pathname;
-        window.history.replaceState({}, "", path);
-      }
-    }
-    handleAuthCallback();
-  }, []);
-
-  useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       setApi((prev) => ({ ...prev, authToken: session?.access_token || "" }));
     });
@@ -51,6 +36,10 @@ export default function App() {
   }, []);
 
   const clipManager = useClipManager(api, storage, uploader);
+
+  if (window.location.pathname === "/auth/callback") {
+    return <AuthCallback />;
+  }
 
   if (!api.authToken) {
     return <LoginScreen onLogin={(token) => setApi({ ...api, authToken: token })} />;

--- a/src/MainApp.tsx
+++ b/src/MainApp.tsx
@@ -43,7 +43,9 @@ export function MainApp({ api, onApiChange }: { api: ApiConfig, onApiChange: (ap
       />
 
       <main className="mx-auto max-w-5xl px-4 py-6 pb-48">
-        {tab === "pending" && <ClipList statuses={["recording", "saved", "uploading", "error"]} />}
+        {tab === "pending" && (
+          <ClipList statuses={["recording", "saved", "queued", "processing", "error"]} />
+        )}
         {tab === "processed" && <ClipList statuses={["uploaded"]} />}
         <audio ref={clipManager.audioRef} className="hidden" />
       </main>

--- a/src/components/AuthCallback.tsx
+++ b/src/components/AuthCallback.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { supabase } from '../utils/supabase';
+
+export function AuthCallback() {
+  useEffect(() => {
+    const run = async () => {
+      const url = new URL(window.location.href);
+      const code = url.searchParams.get('code');
+      if (code) {
+        const { error } = await supabase.auth.exchangeCodeForSession(code);
+        if (error) console.error('exchange error', error);
+      }
+      window.location.replace('/');
+    };
+    run();
+  }, []);
+
+  return null;
+}

--- a/src/components/AuthCallback.tsx
+++ b/src/components/AuthCallback.tsx
@@ -4,6 +4,7 @@ import { supabase } from '../utils/supabase';
 export function AuthCallback() {
   const [isRecovery, setIsRecovery] = useState(false);
   const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -32,7 +33,7 @@ export function AuthCallback() {
         return;
       }
 
-      if (type === 'recovery') {
+      if (type === 'recovery' || (!type && accessToken)) {
         setIsRecovery(true);
       } else {
         window.location.replace('/');
@@ -43,6 +44,10 @@ export function AuthCallback() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    if (password !== confirm) {
+      setError('Passwords do not match');
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -78,6 +83,17 @@ export function AuthCallback() {
             className="w-full px-3 py-2 rounded bg-base text-content border border-subtle focus:outline-none focus:ring-2 focus:ring-primary transition-colors"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1" htmlFor="confirm">Confirm Password</label>
+          <input
+            id="confirm"
+            type="password"
+            className="w-full px-3 py-2 rounded bg-base text-content border border-subtle focus:outline-none focus:ring-2 focus:ring-primary transition-colors"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
             required
           />
         </div>

--- a/src/components/AuthCallback.tsx
+++ b/src/components/AuthCallback.tsx
@@ -11,12 +11,23 @@ export function AuthCallback() {
   useEffect(() => {
     const run = async () => {
       const url = new URL(window.location.href);
-      const code = url.searchParams.get('code');
-      const type = url.searchParams.get('type');
+      const params = url.searchParams;
+      const hashParams = new URLSearchParams(window.location.hash.substring(1));
+      const code = params.get('code');
+      const accessToken = hashParams.get('access_token');
+      const type = params.get('type') || hashParams.get('type');
+
       if (code) {
         const { error } = await supabase.auth.exchangeCodeForSession(code);
         if (error) console.error('exchange error', error);
+      } else if (accessToken) {
+        const { error } = await supabase.auth.getSessionFromUrl({ storeSession: true });
+        if (error) console.error('session error', error);
+      } else {
+        window.location.replace('/');
+        return;
       }
+
       if (type === 'recovery') {
         setIsRecovery(true);
       } else {

--- a/src/components/AuthCallback.tsx
+++ b/src/components/AuthCallback.tsx
@@ -15,13 +15,17 @@ export function AuthCallback() {
       const hashParams = new URLSearchParams(window.location.hash.substring(1));
       const code = params.get('code');
       const accessToken = hashParams.get('access_token');
+      const refreshToken = hashParams.get('refresh_token');
       const type = params.get('type') || hashParams.get('type');
 
       if (code) {
         const { error } = await supabase.auth.exchangeCodeForSession(code);
         if (error) console.error('exchange error', error);
       } else if (accessToken) {
-        const { error } = await supabase.auth.getSessionFromUrl({ storeSession: true });
+        const { error } = await supabase.auth.setSession({
+          access_token: accessToken,
+          refresh_token: refreshToken || ''
+        });
         if (error) console.error('session error', error);
       } else {
         window.location.replace('/');

--- a/src/components/ClipList.tsx
+++ b/src/components/ClipList.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { PlayIcon, StopIcon, UploadIcon, TrashIcon, TagIcon } from "../icons";
 import { fmt } from "../utils/fmt";
 import { useClips } from "../context/clips";
+import type { Clip } from "../models/clip";
 
 export function ClipList({ statuses }: { statuses: Clip["status"][] }) {
   const {

--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -1,60 +1,150 @@
 import { useState } from 'react';
-import { signInWithSupabase } from '../utils/supabase';
+import {
+  resetPasswordWithSupabase,
+  signInWithSupabase,
+  signUpWithSupabase,
+} from '../utils/supabase';
+
+type Mode = 'signIn' | 'signUp' | 'forgot';
 
 export function LoginScreen({ onLogin }: { onLogin: (token: string) => void }) {
+  const [mode, setMode] = useState<Mode>('signIn');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  function resetMessages() {
+    setError(null);
+    setMessage(null);
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
-    setError(null);
+    resetMessages();
     try {
-      const token = await signInWithSupabase(email, password);
-      onLogin(token);
+      if (mode === 'signIn') {
+        const token = await signInWithSupabase(email, password);
+        onLogin(token);
+      } else if (mode === 'signUp') {
+        const token = await signUpWithSupabase(email, password);
+        if (token) {
+          onLogin(token);
+        } else {
+          setMessage('Check your email to confirm your account');
+        }
+      } else if (mode === 'forgot') {
+        await resetPasswordWithSupabase(email);
+        setMessage('Password reset email sent');
+        setMode('signIn');
+      }
     } catch (err: any) {
-      setError(err.message || 'Login failed');
+      setError(err.message || 'Request failed');
     } finally {
       setLoading(false);
     }
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-base text-content">
-      <form onSubmit={handleSubmit} className="bg-surface p-6 rounded shadow-md w-full max-w-sm space-y-4">
-        <h1 className="text-2xl font-bold text-center">Sign In</h1>
-        {error && <div className="text-accent text-sm">{error}</div>}
+    <div className="min-h-screen flex items-center justify-center bg-base text-content transition-colors duration-300">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-surface p-6 rounded shadow-md w-full max-w-sm space-y-4 transition-all duration-300"
+      >
+        <h1 className="text-2xl font-bold text-center">
+          {mode === 'signIn' ? 'Sign In' : mode === 'signUp' ? 'Create Account' : 'Reset Password'}
+        </h1>
+        {error && <div className="text-accent text-sm transition-opacity">{error}</div>}
+        {message && <div className="text-primary text-sm transition-opacity">{message}</div>}
         <div>
           <label className="block text-sm mb-1" htmlFor="email">Email</label>
           <input
             id="email"
             type="email"
-            className="w-full px-3 py-2 rounded bg-base text-content border border-subtle focus:outline-none focus:ring-2 focus:ring-primary"
+            className="w-full px-3 py-2 rounded bg-base text-content border border-subtle focus:outline-none focus:ring-2 focus:ring-primary transition-colors"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required
           />
         </div>
-        <div>
-          <label className="block text-sm mb-1" htmlFor="password">Password</label>
-          <input
-            id="password"
-            type="password"
-            className="w-full px-3 py-2 rounded bg-base text-content border border-subtle focus:outline-none focus:ring-2 focus:ring-primary"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
-        </div>
+        {mode !== 'forgot' && (
+          <div className="transition-all">
+            <label className="block text-sm mb-1" htmlFor="password">Password</label>
+            <input
+              id="password"
+              type="password"
+              className="w-full px-3 py-2 rounded bg-base text-content border border-subtle focus:outline-none focus:ring-2 focus:ring-primary transition-colors"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+        )}
         <button
           type="submit"
           disabled={loading}
-          className="w-full bg-primary text-surface py-2 rounded hover:bg-secondary disabled:opacity-50"
+          className="w-full bg-primary text-surface py-2 rounded hover:bg-secondary disabled:opacity-50 transition-colors"
         >
-          {loading ? 'Signing in...' : 'Sign In'}
+          {loading
+            ? 'Please wait...'
+            : mode === 'forgot'
+            ? 'Send Reset Link'
+            : mode === 'signIn'
+            ? 'Sign In'
+            : 'Sign Up'}
         </button>
+        <div className="text-center text-sm space-y-1">
+          {mode === 'signIn' && (
+            <>
+              <button
+                type="button"
+                className="text-primary hover:underline mr-2 transition-colors"
+                onClick={() => {
+                  setMode('forgot');
+                  resetMessages();
+                }}
+              >
+                Forgot password?
+              </button>
+              <button
+                type="button"
+                className="text-primary hover:underline transition-colors"
+                onClick={() => {
+                  setMode('signUp');
+                  resetMessages();
+                }}
+              >
+                Create account
+              </button>
+            </>
+          )}
+          {mode === 'signUp' && (
+            <button
+              type="button"
+              className="text-primary hover:underline transition-colors"
+              onClick={() => {
+                setMode('signIn');
+                resetMessages();
+              }}
+            >
+              Already have an account?
+            </button>
+          )}
+          {mode === 'forgot' && (
+            <button
+              type="button"
+              className="text-primary hover:underline transition-colors"
+              onClick={() => {
+                setMode('signIn');
+                resetMessages();
+              }}
+            >
+              Back to sign in
+            </button>
+          )}
+        </div>
       </form>
     </div>
   );

--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { signInWithSupabase } from '../utils/supabase';
+
+export function LoginScreen({ onLogin }: { onLogin: (token: string) => void }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const token = await signInWithSupabase(email, password);
+      onLogin(token);
+    } catch (err: any) {
+      setError(err.message || 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-base text-content">
+      <form onSubmit={handleSubmit} className="bg-surface p-6 rounded shadow-md w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-bold text-center">Sign In</h1>
+        {error && <div className="text-accent text-sm">{error}</div>}
+        <div>
+          <label className="block text-sm mb-1" htmlFor="email">Email</label>
+          <input
+            id="email"
+            type="email"
+            className="w-full px-3 py-2 rounded bg-base text-content border border-subtle focus:outline-none focus:ring-2 focus:ring-primary"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1" htmlFor="password">Password</label>
+          <input
+            id="password"
+            type="password"
+            className="w-full px-3 py-2 rounded bg-base text-content border border-subtle focus:outline-none focus:ring-2 focus:ring-primary"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-primary text-surface py-2 rounded hover:bg-secondary disabled:opacity-50"
+        >
+          {loading ? 'Signing in...' : 'Sign In'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2,6 +2,7 @@ import { SaveIcon } from "../icons";
 import type { ApiConfig } from "../services/types";
 import { notesUrl } from "../utils/api";
 import { useTheme, THEMES, type Theme } from "../context/theme";
+import { supabase } from "../utils/supabase";
 
 interface SettingsModalProps {
   api: ApiConfig;
@@ -89,8 +90,21 @@ export function SettingsModal({ api, onApiChange, onClose }: SettingsModalProps)
               Test endpoint
             </button>
           </div>
+          <div className="pt-2">
+            <button
+              onClick={async () => {
+                await supabase.auth.signOut();
+                onApiChange((x) => ({ ...x, authToken: "" }));
+                onClose();
+              }}
+              className="inline-flex items-center gap-2 rounded-xl border border-subtle bg-surface px-4 py-2 text-sm"
+            >
+              Log out
+            </button>
+          </div>
           <div className="text-xs text-muted pt-2">
-            Your settings are saved locally (localStorage). Recordings are stored on-device using IndexedDB until you upload them.
+            Your settings are saved locally (localStorage).
+            Recordings are stored on-device using IndexedDB until you upload them.
           </div>
         </div>
       </div>

--- a/src/context/clips.tsx
+++ b/src/context/clips.tsx
@@ -13,6 +13,7 @@ export interface ClipsContextValue {
   updateClip(id: string, patch: Partial<Clip>): void;
   syncQueued(): void | Promise<void>;
   refreshMetadata(): void | Promise<void>;
+  audioRef: React.RefObject<HTMLAudioElement>;
 }
 
 const ClipsContext = createContext<ClipsContextValue | undefined>(undefined);

--- a/src/services/http-uploader.ts
+++ b/src/services/http-uploader.ts
@@ -33,8 +33,12 @@ export class HttpUploader implements UploadService {
     if (clip.title) fd.append("title", clip.title);
     if (clip.tags?.length) fd.append("tags", JSON.stringify(clip.tags));
 
+    const headers: Record<string, string> = {};
+    if (api.authToken) headers["Authorization"] = `Bearer ${api.authToken}`;
+
     const res = await fetch(notesUrl(api.baseUrl, api.uploadPath), {
       method: "POST",
+      headers,
       body: fd,
     });
     if (!res.ok) {

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = (import.meta.env.VITE_SUPABASE_URL as string) || '';
+const supabaseAnonKey = (import.meta.env.VITE_SUPABASE_ANON_KEY as string) || '';
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export async function signInWithSupabase(email: string, password: string): Promise<string> {
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) throw error;
+  const token = data.session?.access_token;
+  if (!token) throw new Error('No access token returned');
+  return token;
+}
+

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -14,13 +14,19 @@ export async function signInWithSupabase(email: string, password: string): Promi
 }
 
 export async function signUpWithSupabase(email: string, password: string): Promise<string | null> {
-  const { data, error } = await supabase.auth.signUp({ email, password });
+  const redirectTo = `${window.location.origin}/auth/callback`;
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: { emailRedirectTo: redirectTo },
+  });
   if (error) throw error;
   return data.session?.access_token || null;
 }
 
 export async function resetPasswordWithSupabase(email: string): Promise<void> {
-  const { error } = await supabase.auth.resetPasswordForEmail(email);
+  const redirectTo = `${window.location.origin}/auth/callback`;
+  const { error } = await supabase.auth.resetPasswordForEmail(email, { redirectTo });
   if (error) throw error;
 }
 

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -13,3 +13,14 @@ export async function signInWithSupabase(email: string, password: string): Promi
   return token;
 }
 
+export async function signUpWithSupabase(email: string, password: string): Promise<string | null> {
+  const { data, error } = await supabase.auth.signUp({ email, password });
+  if (error) throw error;
+  return data.session?.access_token || null;
+}
+
+export async function resetPasswordWithSupabase(email: string): Promise<void> {
+  const { error } = await supabase.auth.resetPasswordForEmail(email);
+  if (error) throw error;
+}
+

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -3,7 +3,9 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = (import.meta.env.VITE_SUPABASE_URL as string) || '';
 const supabaseAnonKey = (import.meta.env.VITE_SUPABASE_ANON_KEY as string) || '';
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: { persistSession: true, autoRefreshToken: true },
+});
 
 export async function signInWithSupabase(email: string, password: string): Promise<string> {
   const { data, error } = await supabase.auth.signInWithPassword({ email, password });


### PR DESCRIPTION
## Summary
- Switch to `@supabase/supabase-js` for authentication
- Update app to track session and refresh access token via Supabase client
- Store API config without auth token and listen for auth state changes

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bf621b150083309b1262426446111a